### PR TITLE
Sync with upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
               --image-size 2G \
               --repositories-file example/repositories \
               --packages "$(cat example/packages)" \
+              --fs-skel-dir example/rootfs \
+              --fs-skel-chown root:root \
               --script-chroot \
               alpine-$(date +%Y-%m-%d).qcow2 -- ./example/configure.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
               --repositories-file example/repositories \
               --packages "$(cat example/packages)" \
               --script-chroot \
-              alpine-virthardened-$(date +%Y-%m-%d).qcow2 -- ./example/configure.sh
+              alpine-$(date +%Y-%m-%d).qcow2 -- ./example/configure.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install qemu-utils
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright 2017-2021 Jakub Jirutka <jakub@jirutka.cz>.
+Copyright 2017-present Jakub Jirutka <jakub@jirutka.cz>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.adoc
+++ b/README.adoc
@@ -21,10 +21,12 @@ TIP: Don’t need VM, just wanna chroot into Alpine Linux?
 
 * Linux system with common userland (Busybox or GNU coreutils)
 * POSIX-sh compatible shell (e.g. Busybox ash, dash, Bash, ZSH)
-* qemu-img and qemu-nbd (automatically installed by the script if running on Alpine)
-* rsync (needed only for `--fs-skel-dir`; automatically installed by the script if running on Alpine)
-* sfdisk (needed only for `--partition`; automatically installed by the script if running on Alpine)
-* e2fsprogs (for ext4), btrfs-progs (for Btrfs), or xfsprogs (for XFS) (automatically installed by the script if running on Alpine)
+* qemu-img and qemu-nbd
+* rsync (needed only for `--fs-skel-dir`)
+* sfdisk (needed only for `--partition`)
+* e2fsprogs (for ext4), btrfs-progs (for Btrfs), or xfsprogs (for XFS)
+
+All dependencies except the first two are automatically installed by the script when running on Alpine.
 
 
 == Usage

--- a/README.adoc
+++ b/README.adoc
@@ -11,8 +11,10 @@ endif::env-github[]
 This project provides a script for making customized https://alpinelinux.org/[Alpine Linux] disk images for virtual machines.
 It’s quite simple (300 LoC of shell), fast (~32 seconds on GitHub Actions) and requires minimum dependencies (QEMU and filesystem tools).
 
-TIP: Don’t need VM, just want to chroot into Alpine Linux (e.g. on CI)?
+TIP: Don’t need VM, just wanna chroot into Alpine Linux?
      Try https://github.com/alpinelinux/alpine-chroot-install[alpine-chroot-install]!
+     Or do you want to create a custom rootfs?
+     Then https://github.com/alpinelinux/alpine-make-rootfs[alpine-make-rootfs] is for you!
 
 
 == Requirements

--- a/README.adoc
+++ b/README.adoc
@@ -41,6 +41,8 @@ wget https://raw.githubusercontent.com/{gh-name}/v{version}/{script-name} \
     && echo '{script-sha1}  {script-name}' | sha1sum -c \
     || exit 1
 
+Or, if you are on Alpine Linux, you can simply install the https://pkgs.alpinelinux.org/packages?name={script-name}[{script-name}] package.
+
 
 == Pitfalls
 

--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,7 @@ TIP: Don’t need VM, just wanna chroot into Alpine Linux?
 * POSIX-sh compatible shell (e.g. Busybox ash, dash, Bash, ZSH)
 * qemu-img and qemu-nbd (automatically installed by the script if running on Alpine)
 * rsync (needed only for `--fs-skel-dir`; automatically installed by the script if running on Alpine)
+* sfdisk (needed only for `--partition`; automatically installed by the script if running on Alpine)
 * e2fsprogs (for ext4), btrfs-progs (for Btrfs), or xfsprogs (for XFS) (automatically installed by the script if running on Alpine)
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = Make Alpine Linux VM Image
 :script-name: alpine-make-vm-image
-:script-sha1: 1348efd56848ce66442a7fb6666c847ef192e6e2
+:script-sha1: 88b64032dd8d6988f1262267a0a0de2e63a27ae4
 :gh-name: alpinelinux/{script-name}
-:version: 0.10.0
+:version: 0.11.0
 
 ifdef::env-github[]
 image:https://github.com/{gh-name}/workflows/CI/badge.svg["Build Status", link="https://github.com/{gh-name}/actions"]

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = Make Alpine Linux VM Image
 :script-name: alpine-make-vm-image
-:script-sha1: ddf44e4132a32e762cd0ae46e12c0122c5c18877
+:script-sha1: de147fe81402cc21250169a6c7137692c07a8022
 :gh-name: alpinelinux/{script-name}
-:version: 0.8.0
+:version: 0.9.0
 
 ifdef::env-github[]
 image:https://github.com/{gh-name}/workflows/CI/badge.svg["Build Status", link="https://github.com/{gh-name}/actions"]

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = Make Alpine Linux VM Image
 :script-name: alpine-make-vm-image
-:script-sha1: de147fe81402cc21250169a6c7137692c07a8022
+:script-sha1: 1348efd56848ce66442a7fb6666c847ef192e6e2
 :gh-name: alpinelinux/{script-name}
-:version: 0.9.0
+:version: 0.10.0
 
 ifdef::env-github[]
 image:https://github.com/{gh-name}/workflows/CI/badge.svg["Build Status", link="https://github.com/{gh-name}/actions"]

--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,7 @@ TIP: Don’t need VM, just wanna chroot into Alpine Linux?
 * Linux system with common userland (Busybox or GNU coreutils)
 * POSIX-sh compatible shell (e.g. Busybox ash, dash, Bash, ZSH)
 * qemu-img and qemu-nbd (automatically installed by the script if running on Alpine)
+* rsync (needed only for `--fs-skel-dir`; automatically installed by the script if running on Alpine)
 * e2fsprogs (for ext4), btrfs-progs (for Btrfs), or xfsprogs (for XFS) (automatically installed by the script if running on Alpine)
 
 

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -62,10 +62,9 @@
 #
 #   -p --packages PACKAGES                Additional packages to install into the image.
 #
-#   -r --repositories-file REPOS_FILE     Path of repositories file to copy into the rootfs.
-#                                         Default is /etc/apk/repositories. If does not exist,
-#                                         repositories file with Alpine's main and community
-#                                         repositories on --mirror-uri is created.
+#   -r --repositories-file REPOS_FILE     Path of the repositories file to copy into the rootfs.
+#                                         If not provided, Alpine's main and community repositories
+#                                         on --mirror-uri will be used.
 #
 #      --rootfs ROOTFS                    Filesystem to create on the image. Default is ext4.
 #
@@ -367,7 +366,7 @@ done
 : ${KEYS_DIR:="/etc/apk/keys"}
 : ${PACKAGES:=}
 : ${PARTITION:="no"}
-: ${REPOS_FILE:="/etc/apk/repositories"}
+: ${REPOS_FILE:=}
 : ${ROOTFS:="ext4"}
 : ${SCRIPT_CHROOT:="no"}
 : ${SERIAL_CONSOLE:="no"}
@@ -462,7 +461,7 @@ einfo 'Installing base system'
 cd "$mount_dir"
 
 mkdir -p etc/apk/keys
-if [ -f "$REPOS_FILE" ]; then
+if [ "$REPOS_FILE" ]; then
 	install -m 644 "$REPOS_FILE" etc/apk/repositories
 else
 	cat > etc/apk/repositories <<-EOF

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -588,6 +588,8 @@ if grep -qw "$RESOLVCONF_MARK" etc/resolv.conf 2>/dev/null; then
 	EOF
 fi
 
+rm -Rf var/cache/apk/* ||:
+
 einfo 'Completed'
 
 cd - >/dev/null

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -484,6 +484,18 @@ cat > etc/fstab <<-EOF
 EOF
 
 #-----------------------------------------------------------------------
+einfo 'Configuring system'
+
+# We just prepare this config, but don't start the networking service.
+cat > etc/network/interfaces <<-EOF
+	iface lo inet loopback
+
+	iface eth0 inet dhcp
+
+	post-up /etc/network/if-post-up.d/*
+	post-down /etc/network/if-post-down.d/*
+EOF
+
 if [ "$SERIAL_PORT" ]; then
 	echo "$SERIAL_PORT" >> etc/securetty
 	sed -Ei "s|^[# ]*($SERIAL_PORT:.*)|\1|" etc/inittab

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -1,5 +1,7 @@
 #!/bin/sh
 # vim: set ts=4:
+# SPDX-FileCopyrightText: © 2017 Jakub Jirutka <jakub@jirutka.cz>
+# SPDX-License-Identifier: MIT
 #---help---
 # Usage: alpine-make-vm-image [options] [--] <image> [<script> [<script-opts...>]]
 #

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -102,6 +102,8 @@ PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 readonly PROGNAME='alpine-make-vm-image'
 readonly VERSION='0.10.0'
 readonly VIRTUAL_PKG=".make-$PROGNAME"
+# An opaque string used to detect changes in resolv.conf.
+readonly RESOLVCONF_MARK="### created by $PROGNAME ###"
 
 # Alpine APK keys for verification of packages for x86_64.
 readonly ALPINE_KEYS='
@@ -240,6 +242,7 @@ prepare_chroot() {
 	mount_bind /sys "$dest"/sys
 
 	install -D -m 644 /etc/resolv.conf "$dest"/etc/resolv.conf
+	echo "$RESOLVCONF_MARK" >> "$dest"/etc/resolv.conf
 }
 
 # Adds specified services to the runlevel. Current working directory must be
@@ -577,6 +580,14 @@ if [ "$SCRIPT" ]; then
 fi
 
 #-----------------------------------------------------------------------
+if grep -qw "$RESOLVCONF_MARK" etc/resolv.conf 2>/dev/null; then
+	cat > etc/resolv.conf <<-EOF
+		# Default nameservers, replace them with your own.
+		nameserver 1.1.1.1
+		nameserver 2606:4700:4700::1111
+	EOF
+fi
+
 einfo 'Completed'
 
 cd - >/dev/null

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -273,7 +273,7 @@ setup_extlinux() {
 
 	chroot "$mnt" extlinux --install /boot
 	chroot "$mnt" update-extlinux --warn-only 2>&1 \
-		| grep -Fv 'extlinux: cannot open device /dev' >&2
+		| { grep -Fv 'extlinux: cannot open device /dev' ||:; } >&2
 }
 
 # Configures mkinitfs.

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -100,7 +100,7 @@ set -eu
 PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 readonly PROGNAME='alpine-make-vm-image'
-readonly VERSION='0.10.0'
+readonly VERSION='0.11.0'
 readonly VIRTUAL_PKG=".make-$PROGNAME"
 # An opaque string used to detect changes in resolv.conf.
 readonly RESOLVCONF_MARK="### created by $PROGNAME ###"

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -100,8 +100,8 @@ alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub:MIIBIjANBgkqhkiG9w0BAQEFAAOC
 alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub:MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAutQkua2CAig4VFSJ7v54\nALyu/J1WB3oni7qwCZD3veURw7HxpNAj9hR+S5N/pNeZgubQvJWyaPuQDm7PTs1+\ntFGiYNfAsiibX6Rv0wci3M+z2XEVAeR9Vzg6v4qoofDyoTbovn2LztaNEjTkB+oK\ntlvpNhg1zhou0jDVYFniEXvzjckxswHVb8cT0OMTKHALyLPrPOJzVtM9C1ew2Nnc\n3848xLiApMu3NBk0JqfcS3Bo5Y2b1FRVBvdt+2gFoKZix1MnZdAEZ8xQzL/a0YS5\nHd0wj5+EEKHfOd3A75uPa/WQmA+o0cBFfrzm69QDcSJSwGpzWrD1ScH3AK8nWvoj\nv7e9gukK/9yl1b4fQQ00vttwJPSgm9EnfPHLAtgXkRloI27H6/PuLoNvSAMQwuCD\nhQRlyGLPBETKkHeodfLoULjhDi1K2gKJTMhtbnUcAA7nEphkMhPWkBpgFdrH+5z4\nLxy+3ek0cqcI7K68EtrffU8jtUj9LFTUC8dERaIBs7NgQ/LfDbDfGh9g6qVj1hZl\nk9aaIPTm/xsi8v3u+0qaq7KzIBc9s59JOoA8TlpOaYdVgSQhHHLBaahOuAigH+VI\nisbC9vmqsThF2QdDtQt37keuqoda2E6sL7PUvIyVXDRfwX7uMDjlzTxHTymvq2Ck\nhtBqojBnThmjJQFgZXocHG8CAwEAAQ==
 '
 
-: ${APK_TOOLS_URI:="https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.12.9/x86_64/apk.static"}
-: ${APK_TOOLS_SHA256:="5176da3d4c41f12a08b82809aca8e7e2e383b7930979651b8958eca219815af5"}
+: ${APK_TOOLS_URI:="https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.12.10/x86_64/apk.static"}
+: ${APK_TOOLS_SHA256:="d7506bb11327b337960910daffed75aa289d8bb350feab624c52965be82ceae8"}
 
 : ${APK:="apk"}
 : ${APK_OPTS:="--no-progress"}

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -8,12 +8,13 @@
 # This script creates a bootable Alpine Linux disk image for virtual machines.
 # If running on Alpine system (detected by file /etc/alpine-release), then it
 # also installs needed packages on the host system. On other systems you must
-# install them yourself: qemu-img, qemu-nbd, rsync, and mkfs utility for the
-# chosen ROOTFS. If $APK is not available on the host system, then static
-# apk-tools specified by $APK_TOOLS_URI is downloaded and used.
+# install them yourself: qemu-img, qemu-nbd, rsync, sfdisk, and mkfs utility
+# for the chosen ROOTFS. If $APK is not available on the host system, then
+# static apk-tools specified by $APK_TOOLS_URI is downloaded and used.
 #
-# Note that it does not create any partitions (it's really not needed),
-# filesystem is created directly on the image.
+# Note that it does not create any partitions by default (it's really not
+# needed), filesystem is created directly on the image. If you must use some
+# platform that foolishly requires partitions in images, use --partition.
 #
 # Arguments:
 #   <image>                               Path of disk image to use or create if not exists.
@@ -33,6 +34,8 @@
 #
 #      --fs-skel-chown FS_SKEL_CHOWN      Force all files from FS_SKEL_DIR to be owned by the
 #                                         specified USER:GROUP.
+#
+#   -P --partition (PARTITION)            Create GUID Partition Table (GPT) with a single partition.
 #
 #   -f --image-format IMAGE_FORMAT        Format of the disk image (see qemu-img --help).
 #
@@ -169,7 +172,7 @@ attach_image() {
 	local nbd_dev
 
 	nbd_dev=$(get_available_nbd) || {
-		modprobe nbd max_part=0
+		modprobe nbd max_part=16
 		sleep 1
 		nbd_dev=$(get_available_nbd)
 	} || die 'No available nbd device found!'
@@ -321,8 +324,8 @@ wgets() (
 
 #=============================  M a i n  ==============================#
 
-opts=$(getopt -n $PROGNAME -o b:cCf:hi:k:m:p:r:s:S:tv \
-	-l branch:,fs-skel-chown:,fs-skel-dir:,image-format:,image-size:,initfs-features:,kernel-flavor:,keys-dir:,mirror-uri:,no-cleanup,packages:,repositories-file:,rootfs:,script-chroot,serial-console,help,version \
+opts=$(getopt -n $PROGNAME -o b:cCf:hi:k:m:p:Pr:s:S:tv \
+	-l branch:,fs-skel-chown:,fs-skel-dir:,image-format:,image-size:,initfs-features:,kernel-flavor:,keys-dir:,mirror-uri:,no-cleanup,packages:,partition,repositories-file:,rootfs:,script-chroot,serial-console,help,version \
 	-- "$@") || help 1 >&2
 
 eval set -- "$opts"
@@ -340,6 +343,7 @@ while [ $# -gt 0 ]; do
 		-m | --mirror-uri) ALPINE_MIRROR="$2";;
 		-C | --no-cleanup) CLEANUP='no'; n=1;;
 		-p | --packages) PACKAGES="${PACKAGES:-} $2";;
+		-P | --partition) PARTITION='yes'; n=1;;
 		-r | --repositories-file) REPOS_FILE="$(realpath "$2")";;
 		     --rootfs) ROOTFS="$2";;
 		-t | --serial-console) SERIAL_CONSOLE='yes'; n=1;;
@@ -362,6 +366,7 @@ done
 : ${KERNEL_FLAVOR:="virt"}
 : ${KEYS_DIR:="/etc/apk/keys"}
 : ${PACKAGES:=}
+: ${PARTITION:="no"}
 : ${REPOS_FILE:="/etc/apk/repositories"}
 : ${ROOTFS:="ext4"}
 : ${SCRIPT_CHROOT:="no"}
@@ -397,7 +402,7 @@ if [ "$INSTALL_HOST_PKGS" = yes ]; then
 	if ! grep -q -w "$ROOTFS" /proc/filesystems; then
 		modprobe $ROOTFS
 	fi
-	_apk add -t $VIRTUAL_PKG qemu-img $(fs_progs_pkg "$ROOTFS") rsync
+	_apk add -t $VIRTUAL_PKG qemu-img $(fs_progs_pkg "$ROOTFS") rsync sfdisk
 fi
 
 #-----------------------------------------------------------------------
@@ -422,6 +427,17 @@ einfo "Attaching image $IMAGE_FILE as a NBD device"
 
 nbd_dev=$(attach_image "$IMAGE_FILE" "$IMAGE_FORMAT")
 
+
+#-----------------------------------------------------------------------
+if [ "$PARTITION" = yes ]; then
+	einfo 'Creating GPT partition table'
+
+	printf '%s\n' 'label: gpt' 'name=system,type=L,bootable' | sfdisk "$nbd_dev"
+	root_dev="${nbd_dev}p1"
+else
+	root_dev="$nbd_dev"
+fi
+
 #-----------------------------------------------------------------------
 einfo "Formatting image to $ROOTFS"
 
@@ -430,15 +446,15 @@ einfo "Formatting image to $ROOTFS"
 # useless for NBD image and prints confusing error).
 [ "$ROOTFS" = ext4 ] && mkfs_args='-O ^64bit -E nodiscard' || mkfs_args='-K'
 
-mkfs.$ROOTFS -L root $mkfs_args "$nbd_dev"
+mkfs.$ROOTFS -L root $mkfs_args "$root_dev"
 
-root_uuid=$(blk_uuid "$nbd_dev")
+root_uuid=$(blk_uuid "$root_dev")
 mount_dir=$(mktemp -d /tmp/$PROGNAME.XXXXXX)
 
 #-----------------------------------------------------------------------
 einfo "Mounting image at $mount_dir"
 
-mount "$nbd_dev" "$mount_dir"
+mount "$root_dev" "$mount_dir"
 
 #-----------------------------------------------------------------------
 einfo 'Installing base system'

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -1,5 +1,5 @@
 #!/bin/sh
-# vim: set ts=4:
+# vim: set ts=4 sw=4:
 # SPDX-FileCopyrightText: © 2017 Jakub Jirutka <jakub@jirutka.cz>
 # SPDX-License-Identifier: MIT
 #---help---

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -8,9 +8,9 @@
 # This script creates a bootable Alpine Linux disk image for virtual machines.
 # If running on Alpine system (detected by file /etc/alpine-release), then it
 # also installs needed packages on the host system. On other systems you must
-# install them yourself: qemu-img, qemu-nbd, and mkfs utility for the chosen
-# ROOTFS. If $APK is not available on the host system, then static apk-tools
-# specified by $APK_TOOLS_URI is downloaded and used.
+# install them yourself: qemu-img, qemu-nbd, rsync, and mkfs utility for the
+# chosen ROOTFS. If $APK is not available on the host system, then static
+# apk-tools specified by $APK_TOOLS_URI is downloaded and used.
 #
 # Note that it does not create any partitions (it's really not needed),
 # filesystem is created directly on the image.
@@ -27,6 +27,12 @@
 #   -b --branch ALPINE_BRANCH             Alpine branch to install; used only when
 #                                         --repositories-file is not specified. Default is
 #                                         latest-stable.
+#
+#   -S --fs-skel-dir FS_SKEL_DIR          Path of directory which content to recursively copy
+#                                         (using rsync) into / in the image.
+#
+#      --fs-skel-chown FS_SKEL_CHOWN      Force all files from FS_SKEL_DIR to be owned by the
+#                                         specified USER:GROUP.
 #
 #   -f --image-format IMAGE_FORMAT        Format of the disk image (see qemu-img --help).
 #
@@ -315,8 +321,8 @@ wgets() (
 
 #=============================  M a i n  ==============================#
 
-opts=$(getopt -n $PROGNAME -o b:cCf:hi:k:m:p:r:s:tv \
-	-l branch:,image-format:,image-size:,initfs-features:,kernel-flavor:,keys-dir:,mirror-uri:,no-cleanup,packages:,repositories-file:,rootfs:,script-chroot,serial-console,help,version \
+opts=$(getopt -n $PROGNAME -o b:cCf:hi:k:m:p:r:s:S:tv \
+	-l branch:,fs-skel-chown:,fs-skel-dir:,image-format:,image-size:,initfs-features:,kernel-flavor:,keys-dir:,mirror-uri:,no-cleanup,packages:,repositories-file:,rootfs:,script-chroot,serial-console,help,version \
 	-- "$@") || help 1 >&2
 
 eval set -- "$opts"
@@ -324,6 +330,8 @@ while [ $# -gt 0 ]; do
 	n=2
 	case "$1" in
 		-b | --branch) ALPINE_BRANCH="$2";;
+		-S | --fs-skel-dir) FS_SKEL_DIR="$(realpath "$2")";;
+		     --fs-skel-chown) FS_SKEL_CHOWN="$2";;
 		-f | --image-format) IMAGE_FORMAT="$2";;
 		-s | --image-size) IMAGE_SIZE="$2";;
 		-i | --initfs-features) INITFS_FEATURES="${INITFS_FEATURES:-} $2";;
@@ -346,6 +354,8 @@ done
 : ${ALPINE_BRANCH:="latest-stable"}
 : ${ALPINE_MIRROR:="http://dl-cdn.alpinelinux.org/alpine"}
 : ${CLEANUP:="yes"}
+: ${FS_SKEL_CHOWN:=}
+: ${FS_SKEL_DIR:=}
 : ${IMAGE_FORMAT:=}
 : ${IMAGE_SIZE:="2G"}
 : ${INITFS_FEATURES:="scsi virtio"}
@@ -387,7 +397,7 @@ if [ "$INSTALL_HOST_PKGS" = yes ]; then
 	if ! grep -q -w "$ROOTFS" /proc/filesystems; then
 		modprobe $ROOTFS
 	fi
-	_apk add -t $VIRTUAL_PKG qemu-img $(fs_progs_pkg "$ROOTFS")
+	_apk add -t $VIRTUAL_PKG qemu-img $(fs_progs_pkg "$ROOTFS") rsync
 fi
 
 #-----------------------------------------------------------------------
@@ -521,6 +531,19 @@ fi
 #-----------------------------------------------------------------------
 if [ -L /etc/apk/cache ]; then
 	rm etc/apk/cache >/dev/null 2>&1
+fi
+
+#-----------------------------------------------------------------------
+if [ "$FS_SKEL_DIR" ]; then
+	einfo "Copying content of $FS_SKEL_DIR into image"
+
+	[ "$FS_SKEL_CHOWN" ] \
+		&& rsync_opts="--chown $FS_SKEL_CHOWN" \
+		|| rsync_opts='--numeric-ids'
+	rsync --archive --info=NAME2 --whole-file $rsync_opts "$FS_SKEL_DIR"/ . >&2
+
+	# rsync may modify perms of the rootfs dir itself, so make sure it's correct.
+	install -d -m 0755 -o root -g root .
 fi
 
 #-----------------------------------------------------------------------

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -98,7 +98,7 @@ set -eu
 PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 readonly PROGNAME='alpine-make-vm-image'
-readonly VERSION='0.9.0'
+readonly VERSION='0.10.0'
 readonly VIRTUAL_PKG=".make-$PROGNAME"
 
 # Alpine APK keys for verification of packages for x86_64.

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -92,7 +92,7 @@ set -eu
 PATH="$PATH:/usr/sbin:/usr/bin:/sbin:/bin"
 
 readonly PROGNAME='alpine-make-vm-image'
-readonly VERSION='0.8.0'
+readonly VERSION='0.9.0'
 readonly VIRTUAL_PKG=".make-$PROGNAME"
 
 # Alpine APK keys for verification of packages for x86_64.

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -485,8 +485,8 @@ EOF
 
 #-----------------------------------------------------------------------
 if [ "$SERIAL_PORT" ]; then
-	echo "$SERIAL_PORT" >> "$mount_dir"/etc/securetty
-	sed -Ei "s|^[# ]*($SERIAL_PORT:.*)|\1|" "$mount_dir"/etc/inittab
+	echo "$SERIAL_PORT" >> etc/securetty
+	sed -Ei "s|^[# ]*($SERIAL_PORT:.*)|\1|" etc/inittab
 fi
 
 #-----------------------------------------------------------------------

--- a/alpine-make-vm-image
+++ b/alpine-make-vm-image
@@ -313,7 +313,7 @@ wgets() (
 
 #=============================  M a i n  ==============================#
 
-opts=$(getopt -n $PROGNAME -o b:cCf:hi:k:p:r:s:tv \
+opts=$(getopt -n $PROGNAME -o b:cCf:hi:k:m:p:r:s:tv \
 	-l branch:,image-format:,image-size:,initfs-features:,kernel-flavor:,keys-dir:,mirror-uri:,no-cleanup,packages:,repositories-file:,rootfs:,script-chroot,serial-console,help,version \
 	-- "$@") || help 1 >&2
 

--- a/example/configure.sh
+++ b/example/configure.sh
@@ -32,3 +32,6 @@ rc-update add crond default
 rc-update add net.eth0 default
 rc-update add net.lo boot
 rc-update add termencoding boot
+
+step 'List /usr/local/bin'
+ls -la /usr/local/bin

--- a/example/packages
+++ b/example/packages
@@ -1,6 +1,7 @@
 chrony
+doas
+doas-sudo-shim
 less
 logrotate
 openssh
 ssmtp
-sudo

--- a/example/rootfs/usr/local/bin/hello
+++ b/example/rootfs/usr/local/bin/hello
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo 'Hello, world!'


### PR DESCRIPTION
- Fix missing -m in getopt
- Don't fail if update-extlinux doesn't produce expected error message
- License: Update year
- Update apk-tools to 2.12.10
- Readme: Add link to alpine-make-rootfs
- CI: Remove "virthardened" from image name
- Use relative paths in serial console part
- Prepare /etc/network/interfaces with lo and eth0 dhcp
- Add SPDX license headers to script
- Release version 0.9.0
- Add sw=4 to vim modeline
- example: Replace sudo with doas, doas-sudo-shim
- Add options --fs-skel-dir, --fs-skel-chown
- Release version 0.10.0
- Readme: Add rsync to Requirements
- Add option to create GPT partition table
- Readme: Refactor Requirements
- Do not default to using /etc/apk/repositories
- Replace resolv.conf with default if not modified by user
- Delete /var/cache/apk/* when done
- CI: Update actions/checkout to v3
- Readme: Add info about installing from Alpine package
- Release version 0.11.0
